### PR TITLE
Fix incorrect css link color placement for dark mode

### DIFF
--- a/layout/less/list.less
+++ b/layout/less/list.less
@@ -48,18 +48,18 @@
         word-break: break-all;
         white-space: normal;
     }
-}
 
-/* If the client prefers a dark color scheme, the following classes will be
- * applied to give the site a dark look and feel.
- *
- * NOTE: These classes need to be at the end of this file, as they override the
- *       default settings previously defined, if the dark color scheme is
- *       requested. */
-@media (prefers-color-scheme: dark) {
-    a,
-    a:hover,
-    a:focus {
-        color: white;
+    /* If the client prefers a dark color scheme, the following classes will be
+     * applied to give the site a dark look and feel.
+     *
+     * NOTE: These classes need to be at the end of this file, as they override the
+     *       default settings previously defined, if the dark color scheme is
+     *       requested. */
+    @media (prefers-color-scheme: dark) {
+        a,
+        a:hover,
+        a:focus {
+            color: @white;
+        }
     }
 }


### PR DESCRIPTION
This fixes the link color in dark mode, the previous commit did not fix it in my browser, tested on Chrome 95 and Firefox 94,